### PR TITLE
Define (**) for AD type explicitly

### DIFF
--- a/src/Numeric/AD/DelCont/Internal.hs
+++ b/src/Numeric/AD/DelCont/Internal.hs
@@ -180,6 +180,7 @@ instance Floating a => Floating (AD s a a) where
   exp = op1Num $ \x -> (exp x, (exp x *))
   log = op1Num $ \x -> (log x, (/x))
   sqrt = op1Num $ \x -> (sqrt x, (/ (2 * sqrt x)))
+  (**) = op2Num $ \x y -> (x ** y, (* (y * x ** (y - 1))), (* (x ** y * log x)))
   logBase = op2Num $ \x y ->
                        let
                          dx = - logBase x y / (log x * x)

--- a/test/Numeric/AD/DelContSpec.hs
+++ b/test/Numeric/AD/DelContSpec.hs
@@ -11,11 +11,14 @@ spec = do
   describe "rad1 : Unary functions" $ do
     let
       x0 = 1.2
+      x1 = 0.0
     it "(** 2)" $ do
       let
         f x = x ** 2
         (_, dfdx) = rad1 f x0
+        (_, dfdx1) = rad1 f x1
       dfdx `shouldBe` 2.4
+      dfdx1 `shouldBe` 0.0
     it "sqrt" $ do
       let
         (_, dfdx) = rad1 sqrt x0


### PR DESCRIPTION
Using implicit definition

```haskell
x ** y = exp (log x * y)
```

makes its gradient to be

```haskell
[(y * exp (log x * y)) / x, log x * exp (log x * y)]
```

and it's problematic when `x = 0`.