### PR TITLE
Add Numeric.AD.DelContSpec to other-modules

### DIFF
--- a/ad-delcont.cabal
+++ b/ad-delcont.cabal
@@ -48,6 +48,7 @@ test-suite spec
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
+  other-modules:       Numeric.AD.DelContSpec
   build-depends:       base
                      , ad-delcont
                      , hspec


### PR DESCRIPTION
It is necessary to include `test/Numeric/AD/DelContSpec.hs` in the source distribution.